### PR TITLE
Added opinions

### DIFF
--- a/items.json
+++ b/items.json
@@ -15,6 +15,9 @@
                 "amongAll": 1
             }
         },
+        "copy": {
+            "opinions": "Lexical: A Tailored Solution with Room for Growth\n\nOverview:\nLexical is a strong choice for those seeking a customizable and scalable editor tailored to specific design systems. However, it may require additional effort to build out certain features.\n\nAdvantages:\n- Customizable and Lightweight: Lexical allows you to integrate only the necessary functionality, ensuring a lightweight and efficient core.\n- Design and Functional Control: The platform offers complete control over both the design and functionality, making it ideal for tailored solutions.\n- Collaboration Features: It appears to include a free collaboration feature, which is a significant advantage.\n\nDrawbacks:\n- Documentation Gaps: The available documentation could be more robust, often necessitating exploration of their playground code for clarity.\n- Smaller Ecosystem: Compared to other editors, Lexical's ecosystem is relatively limited."
+        },
         "properties": {
             "version": "0.19.0",
             "description": "Lexical is an extensible text editor framework that provides excellent reliability, accessibility and performance.",
@@ -29,7 +32,10 @@
             "releaseDate": "2024-10-28",
             "originalReleaseDate": "2022-01-10",
             "publisher": "Meta",
-            "comment": null
+            "comment": null,
+            "tech": {
+                "react": { "link": "https://lexical.dev/docs/getting-started/react" }
+            }
         }
     },
     {
@@ -64,6 +70,9 @@
             "ranking": {
                 "amongAll": 2
             }
+        },
+        "copy": {
+            "opinions": "Plate: A flexible and modern rich text editor for developers \n\nOverview:\nThe Plate rich text editor has garnered a mix of feedback from users, reflecting both its strengths and areas for improvement. This document organizes the feedback into key themes, highlighting the editor's advantages, drawbacks, and potential for enhancement.  \n\nAdvantages:\n- Customizability: Users appreciated the editor's high level of customizability, allowing developers to tailor it to specific project needs. This flexibility makes it a strong choice for diverse applications.  \n- Robust API: Many noted that the API is well-documented and easy to work with, streamlining integration into existing systems.  \n-. Modern Design: The user interface was frequently described as intuitive and visually appealing, providing a positive user experience.  \n- Performance: Feedback praised the editor for its efficient handling of complex documents and large data inputs without significant lag.  \n\nDrawbacks:\n- Learning Curve: While powerful, some users found the editor's advanced features and configuration options difficult to learn, particularly for those new to rich text editors.  \n- Limited Out-of-the-Box Features: Users noted that several essential features are not included by default and require additional configuration or plugins.  \n- Compatibility Issues: Some users encountered occasional bugs or inconsistencies when integrating the editor with certain frameworks or libraries.  \n- Cost: For some, the licensing fees were seen as higher compared to competitors, making it less accessible for smaller projects or organizations.  \n\nConclusion:  \nThe Plate rich text editor stands out for its customizability, robust API, and modern design, making it a solid choice for developers seeking a flexible tool for managing rich text. However, a steep learning curve, reliance on plugins for basic features, and cost concerns may limit its appeal for some users. Addressing these drawbacks could make the editor even more compelling in the market."
         },
         "properties": {
             "version": "39.0.0",
@@ -115,6 +124,9 @@
                 "amongAll": 1
             }
         },
+        "copy": {
+            "opinions": "TipTap: A flexible and extensible rich text editor with room for growth\n\nOverview\nTipTap is a modern, open-source rich text editor built on ProseMirror. It offers a modular architecture, allowing developers to integrate only the desired features while providing robust support for extensibility and customization. Its comprehensive documentation and versatile output formats make it a strong contender for projects requiring advanced text editing capabilities.  \n\nAdvantages\n- TipTap allows developers to integrate only the functionality they need, ensuring a leaner implementation.  \n- It supports multiple output formats, including plain text, HTML, JSON, and markdown (albeit without link support).  \n- The editor is highly extensible, enabling the development of custom commands and functionalities tailored to specific use cases.  \n- A wide variety of extensions are available to implement specialized features, simplifying complex requirements.  \n- Built-in collaboration capabilities make it suitable for real-time multi-user applications.  \n- Comprehensive documentation and examples, including integration guides for frameworks like Next.js, facilitate smooth onboarding.  \n- Migrating existing content to TipTap is straightforward, reducing friction in adoption.  \n\nDrawbacks\n- Implementing custom commands relies heavily on familiarity with ProseMirror, which can increase the development burden.  \n- TipTap's ecosystem is relatively small; for example, the Footnotes library is a recent addition, reflecting limited maturity in certain areas.  \n- Image insertion is limited to URL-based methods, restricting user flexibility in adding media.  \n- Version 2.0 is still in beta, while version 1.0 has been deprecated, posing potential stability concerns.  \n- There are a few unresolved issues related to mobile support, particularly for rich text features, as highlighted on GitHub.  \n\nConclusion\nTipTap stands out as a flexible and extensible rich text editor, particularly for projects requiring tailored solutions and collaborative editing. However, its smaller ecosystem, beta status of its latest version, and some limitations in features like mobile support may pose challenges for teams. Careful consideration of project requirements and a willingness to navigate its reliance on ProseMirror will ensure successful integration."
+        },
         "properties": {
             "version": "2.9.1",
             "description": "The headless rich text editor framework for web artisans.",
@@ -165,6 +177,9 @@
                 "amongAll": 1
             }
         },
+        "copy": {
+            "opinions": "TinyMCE: A Flexible Yet Challenging Rich Text Editor for Diverse Needs\n\nOverview\nTinyMCE is a versatile and widely recognized rich text editor, valued for its extensive functionality and adaptability. With a long history and broad compatibility with modern frameworks, it caters to a wide range of use cases, from basic text editing to advanced real-time collaboration. However, while its flexibility and features are notable, users often encounter challenges in customization and consistency.\n\nAdvantages\n- TinyMCE allows integration of only the specific functionality required, ensuring tailored implementations.  \n- With a well-established presence in the market, it has earned a reputation for reliability.  \n- Supports content output in HTML and Markdown formats (Markdown links available in the paid version).  \n- Features an expansive library of extensions, offering endless customization possibilities.  \n- Seamlessly integrates with popular frameworks like React, Vue, and Angular.  \n- Offers various plugins and style customization options to adapt to specific design needs.  \n- Includes advanced features like real-time collaboration in its premium version.  \n\nDrawbacks\n- Custom styling demands significant effort, which can be time-intensive.  \n- Modifying existing functionality is complex; creating new plugins is often more efficient, but this approach negates the advantage of utilizing pre-existing extensions.  \n- Lacks a unified and cohesive look and feel, with styles often hardcoded, limiting flexibility.  \n- Configuration options are not straightforward, highlighting the need for more intuitive setup guidance.  \n\nConclusion\nTinyMCE is a robust tool that excels in flexibility and feature richness, making it suitable for diverse applications and frameworks. While its modularity and plugin ecosystem are major strengths, the challenges associated with customization and achieving a consistent design may require significant investment of time and resources. Addressing these areas could enhance its appeal and usability for a broader audience."
+        },
         "properties": {
             "version": "7.5.0",
             "description": "The world's #1 JavaScript library for rich text editing. Available for React, Vue and Angular",
@@ -214,6 +229,9 @@
             "ranking": {
                 "amongAll": 1
             }
+        },
+        "copy": {
+            "opinions": "CKEditor: a versatile and long-established editor with some customization challenges\n\nOverview\nCKEditor is a robust and widely-used rich text editor that has been a staple in the industry for many years. It offers a range of features that make it a strong choice for developers and content creators alike. However, while its versatility is praised, certain aspects, particularly related to customization and documentation, pose challenges for users.\n\nAdvantages\n- CKEditor has a long-standing reputation, benefiting from years of development and refinement.  \n- Users can tailor the editor to their needs by integrating only the necessary functionalities.  \n- It supports content output in both HTML and Markdown formats, accommodating diverse requirements.  \n- A wide variety of plugins and a headless option make it highly adaptable for different use cases.  \n\nDrawbacks\n- The documentation is detailed but can feel overly complex and difficult to navigate.  \n- Search results for troubleshooting often lead to outdated references to older CKEditor versions with deprecated APIs.  \n- Customizing specific features, such as link functionality, has been described as more cumbersome compared to alternatives like TipTap.  \n- General customization can be challenging, potentially hindering developer efficiency.  \n\nConclusion\nCKEditor remains a powerful and flexible tool with a rich ecosystem of features and plugins. However, improving its documentation and simplifying customization processes would make it more accessible and user-friendly, particularly for developers working with modern requirements."
         },
         "properties": {
             "version": "43.3.1",
@@ -331,6 +349,9 @@
                 "amongAll": 1
             }
         },
+        "copy": {
+            "opinions": "Editor.js: suitable for basic Use but limited for customization\n\nOverview\nEditor.js provides essential functionality for creating and managing rich text content, making it a useful tool for straightforward applications. However, users seeking extensive customization or advanced features may find it less accommodating. \n\nAdvantages\n- Satisfies basic functionality requirements effectively.  \n- Straightforward to implement for simple use cases.  \n\nDrawbacks\n- Customizing the user interface to meet specific client requirements proved difficult and unreliable.  \n- The lack of React-based architecture limits its compatibility and flexibility in certain development environments.  \n- Controlling keyboard event handlers posed significant challenges, reducing ease of integration.  \n\nConclusion\nWhile Editor.js performs well for basic needs, it struggles to deliver the flexibility and reliability required for more extensive customizations or larger-scale projects. Developers should consider these limitations when choosing the tool for their specific needs."
+        },
         "properties": {
             "version": "2.30.6",
             "description": "A block-styled editor with clean JSON output.",
@@ -364,6 +385,9 @@
                 "amongAll": 1
             }
         },
+        "copy": {
+            "opinions": "Trix: lightweight and easy to use with limited flexibility\n\nOverview\nThe Trix rich text editor is a lightweight, pure JavaScript and SCSS-based solution designed for simple text editing use cases. It offers a straightforward setup process with minimal configuration required, making it an appealing choice for basic applications. However, it has limitations when it comes to customizing the user interface (UI) and extending its functionality.\n\nAdvantages\n- Lightweight, built with pure JavaScript and SCSS, ensuring fast performance and ease of integration.\n- Simple and quick setup with minimal configuration needed, making it ideal for projects requiring a fast implementation.\n\nDrawbacks\n- The editor offers limited flexibility when it comes to customizing the user interface or adding advanced features.\n- There is no native support for popular frameworks like React, Vue, or Angular, which may hinder integration with more complex applications.\n\nConclusion\nTrix is an excellent choice for straightforward, simple text editing tasks, especially for projects that prioritize ease of setup and lightweight performance. However, its lack of flexibility and support for modern JavaScript frameworks may limit its usefulness in more complex or customizable scenarios."
+        },
         "properties": {
             "version": "2.1.8",
             "description": "A rich text editor for everyday writing. Compose beautifully formatted text in your web application.",
@@ -396,6 +420,9 @@
             "ranking": {
                 "amongAll": 1
             }
+        },
+        "copy": {
+            "opinions": "Quill: community-driven with some limitations\n\nOverview\nQuill is a widely-used rich text editor that has been in the market for several years, offering cross-platform support and a variety of features. While it provides essential functionalities like image upload, the editor's reliance on community-driven plugins and its out-of-the-box styling can present challenges for certain use cases.\n\nAdvantages\n- Supports image upload functionality  \n- Strong emphasis on cross-platform compatibility  \n- Established and widely used for many years  \n\nDrawbacks\n- More complex API with smaller documentation compared to alternatives like TipTap  \n- Includes built-in styling, making it less \"headless\" than some other editors  \n- Migrating existing content may be a cumbersome process  \n\nConclusion\nQuill is a solid choice for developers looking for a feature-rich editor with good cross-platform support. However, its reliance on community plugins, more complex API, and built-in styling might limit its appeal for projects requiring a more lightweight or customizable solution."
         },
         "properties": {
             "version": "2.0.2",


### PR DESCRIPTION
Generated via ChatGPT with [data from the spreadsheet](https://docs.google.com/spreadsheets/d/1ZOwSgZ1iStzq1n60n5guHxovQE_YzZM6K89SVjXUoto/edit?gid=1156210878#gid=1156210878) and the following prompt:

```
This is some raw feedback from users of the XXX rich text editor.
Rewrite it into a more professional way. Include a title and 4 sections: Overview, Advantages, Drawbacks, and Conclusion. Return plain text. Don't number bullet point items. The title should be a single sentence summarizing of the high-level points made in the feedback.

xxxxxx

Pros:
xxxxxx

Cons:
xxxxx
```

This isn't looking too hot right now, so I'll see about tweaking the opinion tooltip settings or replace it altogether with a popover or a dialog:

<img width="500" alt="Screenshot of the stage with an opinion tooltip showing" src="https://github.com/user-attachments/assets/10341364-a7c3-4ac1-9408-965ad9307ab6" />
