### PR TITLE
Fixing bug where backticks were causing a build script to wrongly output </div> inside a script.

### DIFF
--- a/completed/trix/dist/index.html
+++ b/completed/trix/dist/index.html
@@ -21,9 +21,9 @@
   "drawbacks": [
     "Limited flexibility in UI customization and extending functionality beyond its default features.",
     "No native support for modern frameworks like React, Vue, or Angular, making integration with complex applications more challenging.",
-    "Trix replaces `<p>` elements with `</p><div>`s and adds extra `<br>` tags to preserve spacing, sometimes leading to unexpected formatting when parsing preloaded HTML."
+    "Trix replaces p elements with div's and adds extra br tags to preserve spacing, sometimes leading to unexpected formatting when parsing preloaded HTML."
   ],
   "conclusion": "Trix is an excellent choice for straightforward, simple text editing tasks, especially for projects that prioritize ease of setup and lightweight performance. However, its lack of flexibility and support for modern JavaScript frameworks may limit its usefulness in more complex or customizable scenarios."
-}</div></script>
+}</script>
   
 </html>

--- a/completed/trix/index.html
+++ b/completed/trix/index.html
@@ -21,9 +21,9 @@
   "drawbacks": [
     "Limited flexibility in UI customization and extending functionality beyond its default features.",
     "No native support for modern frameworks like React, Vue, or Angular, making integration with complex applications more challenging.",
-    "Trix replaces `<p>` elements with `</p><div>`s and adds extra `<br>` tags to preserve spacing, sometimes leading to unexpected formatting when parsing preloaded HTML."
+    "Trix replaces p elements with div's and adds extra br tags to preserve spacing, sometimes leading to unexpected formatting when parsing preloaded HTML."
   ],
   "conclusion": "Trix is an excellent choice for straightforward, simple text editing tasks, especially for projects that prioritize ease of setup and lightweight performance. However, its lack of flexibility and support for modern JavaScript frameworks may limit its usefulness in more complex or customizable scenarios."
-}</div></script>
+}</script>
   
 </html>

--- a/items.json
+++ b/items.json
@@ -548,7 +548,7 @@
                 "drawbacks": [
                     "Limited flexibility in UI customization and extending functionality beyond its default features.",
                     "No native support for modern frameworks like React, Vue, or Angular, making integration with complex applications more challenging.",
-                    "Trix replaces `<p>` elements with `<div>`s and adds extra `<br>` tags to preserve spacing, sometimes leading to unexpected formatting when parsing preloaded HTML."
+                    "Trix replaces p elements with div's and adds extra br tags to preserve spacing, sometimes leading to unexpected formatting when parsing preloaded HTML."
                 ],
                 "conclusion": "Trix is an excellent choice for straightforward, simple text editing tasks, especially for projects that prioritize ease of setup and lightweight performance. However, its lack of flexibility and support for modern JavaScript frameworks may limit its usefulness in more complex or customizable scenarios."
             }


### PR DESCRIPTION
Probably some escaping missing somewhere. Backticks in items.json are forbidden now.